### PR TITLE
Fix warning on php8

### DIFF
--- a/src/JavierLeon9966/ExtendedBlocks/item/ItemFactory.php
+++ b/src/JavierLeon9966/ExtendedBlocks/item/ItemFactory.php
@@ -58,7 +58,7 @@ class ItemFactory extends PMFactory{
 			}
 		}
 	}
-	final private static function jsonDeserialize(array $data): Item{
+	private static function jsonDeserialize(array $data): Item{
 		$nbt = "";
 
 		//Backwards compatibility


### PR DESCRIPTION
This PR fixes below warning on php8.
```bash
Warning: Private methods cannot be final as they are never overridden by other classes in phar://D:/Repository/pmmp/plugins/ExtendedBlocks.phar/src/JavierLeon9966/ExtendedBlocks/item/ItemFactory.php on line 61
```